### PR TITLE
Add GitHub actions workflow for Litani tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Litani tests
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the release branch
+  push:
+    branches: [ release, develop ]
+  pull_request:
+    branches: [ release, develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "ubuntu-build"
+  ubuntu-build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs tests
+      - name: Run tests
+        run: ./test/run
+
+  # This workflow contains a single job called "macos-build"
+  macos-build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs tests
+      - name: Run tests
+        run: ./test/run
+
+  # This workflow contains a single job called "windows-build"
+  windows-build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs tests
+      - name: Run tests
+        run: ./test/run
+


### PR DESCRIPTION
Run existing tests on Ubuntu 20.04, latest Windows and latest macOS.

This workflow can be run ad hoc from the actions tab or on PR and push events for the develop and release branches.